### PR TITLE
fix: continue serving old segments when unable to transcode in realtime

### DIFF
--- a/ErsatzTV.Core.Tests/FFmpeg/HlsPlaylistFilterTests.cs
+++ b/ErsatzTV.Core.Tests/FFmpeg/HlsPlaylistFilterTests.cs
@@ -996,6 +996,46 @@ live_1760874038_000056.m4s
         result.Playlist.ShouldBe(expectedPlaylist);
     }
 
+    [Test]
+    public void HlsPlaylistFilter_ShouldKeepSegments_WhenNoneAreNewerThanFilterBefore()
+    {
+        // long session: the transcode has fallen behind and every segment is now older
+        // than filterBefore. trimming used to remove all of them and emit a header-only
+        // playlist with no segments, which leaves the channel unplayable.
+        var start = new DateTimeOffset(2021, 10, 9, 8, 0, 0, TimeSpan.FromHours(-5));
+        string[] input = NormalizeLineEndings(
+            @"#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-TARGETDURATION:4
+#EXT-X-MEDIA-SEQUENCE:1137
+#EXT-X-INDEPENDENT-SEGMENTS
+#EXT-X-DISCONTINUITY
+#EXT-X-MAP:URI=""1760874038_init.mp4""
+#EXTINF:4.000000,
+#EXT-X-PROGRAM-DATE-TIME:2021-10-08T08:34:49.320-0500
+live_1760874038_001137.m4s
+#EXTINF:4.000000,
+#EXT-X-PROGRAM-DATE-TIME:2021-10-08T08:34:53.320-0500
+live_1760874038_001138.m4s
+#EXTINF:4.000000,
+#EXT-X-PROGRAM-DATE-TIME:2021-10-08T08:34:57.320-0500
+live_1760874038_001139.m4s").Split(Environment.NewLine);
+
+        TrimPlaylistResult result = _hlsPlaylistFilter.TrimPlaylistWithDiscontinuity(
+            new Dictionary<long, int>
+            {
+                [1760874038] = 1
+            },
+            OutputFormatKind.HlsMp4,
+            start,
+            start.AddSeconds(60),
+            new FakeHlsInitSegmentCache(),
+            input);
+
+        result.SegmentCount.ShouldBeGreaterThan(0);
+        result.Playlist.ShouldContain("#EXTINF");
+    }
+
     private static string NormalizeLineEndings(string str) =>
         str
             .Replace("\r\n", "\n")

--- a/ErsatzTV.Core/FFmpeg/HlsPlaylistFilter.cs
+++ b/ErsatzTV.Core/FFmpeg/HlsPlaylistFilter.cs
@@ -148,8 +148,10 @@ public class HlsPlaylistFilter(ITempFilePool tempFilePool, ILogger<HlsPlaylistFi
 
         var allSegments = items.OfType<PlaylistSegment>().ToList();
 
-        // still need to filter old content
-        if (maybeMaxSegments.IsNone)
+        // still need to filter old content, but never down to an empty playlist:
+        // if nothing is newer than filterBefore, keep the existing segments
+        // (the maxSegments branch below keeps a non-empty tail the same way)
+        if (maybeMaxSegments.IsNone && allSegments.Any(s => s.StartTime >= filterBefore))
         {
             allSegments.RemoveAll(s => s.StartTime < filterBefore);
         }
@@ -268,7 +270,7 @@ public class HlsPlaylistFilter(ITempFilePool tempFilePool, ILogger<HlsPlaylistFi
             playlist,
             nextPlaylistStart,
             startSequence,
-            items.OfType<PlaylistSegment>().Min(s => s.GeneratedAt),
+            items.OfType<PlaylistSegment>().Select(s => s.GeneratedAt).DefaultIfEmpty(generatedAt).Min(),
             allSegments.Count);
     }
 


### PR DESCRIPTION
Between transcodes, the session worker trims the on-disk playlist before the next ffmpeg process appends, dropping any segment older than 60 seconds (`HlsSessionWorker.TrimAndDelete`, `Now.AddMinutes(-1)`). If the transcode has fallen at least 60 seconds behind, every segment is older than that cutoff, so the trim removes all of them and writes a playlist with no segments. If the playlist read back already has no segments, the `Min` over generated-at throws, which logs the bad playlist and writes it out empty.

This keeps the current segments when none are newer than the cutoff, the same way the maxSegments path already does, and falls back instead of throwing on the empty case. The test trims past the newest segment to cover it.
