### PR TITLE
fix: key singleton mutex on config folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Playlists ignored this setting in earlier builds
 - Always randomize start points for all collections the first time they are used
   - Previously, only collections scheduled during the first day of a playout build had their start points randomized
+- Allow multiple ETV instances when multiple config folders are used
 
 ## [26.6.0] - 2026-07-09
 ### Added

--- a/ErsatzTV/Program.cs
+++ b/ErsatzTV/Program.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
 using Destructurama;
 using ErsatzTV.Core;
 using ErsatzTV.Services.Validators;
@@ -47,9 +49,14 @@ public class Program
 
     public static async Task<int> Main(string[] args)
     {
+        // Keyed on the config folder, not a constant, so an instance running against an
+        // isolated ETV_CONFIG_FOLDER (a staging copy) can coexist with the primary one.
+        string singletonId = Convert.ToHexString(
+            SHA256.HashData(Encoding.UTF8.GetBytes(FileSystemLayout.AppDataFolder)))[..16];
+
         using var _ = new Mutex(
             true,
-            "Global\\ErsatzTV.Singleton.74360cd8985c4d1fb6bc9e81887206fe",
+            $"Global\\ErsatzTV.Singleton.{singletonId}",
             out bool createdNew);
         if (!createdNew)
         {


### PR DESCRIPTION
**Description of the issue**
Using a fixed string Global\ constant creates a machine wide block. Only one ErsatzTV can run on the entire machine ever, no matter the config folder, port, db an instance is pointed at. From my findings the guard is meant to stop multiple processes from hammering the same sqlite db at once, which would potentially corrupt it.

**The fix**
This fix keys the name on the config folder instead a short SHA-256 hash of `FileSystemLayout.AppDataFolder`:
`$"Global\\ErsatzTV.Singleton.{singletonId}"`

Two instances with different config folders now compute different names and can coexist. However two instances pointing at the same config folder still collide, so the guard still handles this.

**Purpose**
If users want/need to stand up a second instance of ErsatzTV with an isolated copy of the DB for testing migrations or any other function while not impacting the live instance.

