### PR TITLE
fix: discover tests in ErsatzTV.Tests

### DIFF
--- a/ErsatzTV.Tests/ErsatzTV.Tests.csproj
+++ b/ErsatzTV.Tests/ErsatzTV.Tests.csproj
@@ -12,6 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
       <PackageReference Include="NUnit" Version="4.6.1" />
       <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
         <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
`ErsatzTV.Tests` references NUnit, NUnit3TestAdapter and Shouldly, but not `Microsoft.NET.Test.Sdk`. Without it, `dotnet test` builds the project and then discovers nothing in it: no warning, no error, exit code 0.

The result is that a solution-wide `dotnet test` reports four projects instead of five:

```
Passed! - Failed: 0, Passed:   18, ... ErsatzTV.FFmpeg.Tests.dll
Passed! - Failed: 0, Passed:    8, ... ErsatzTV.Infrastructure.Tests.dll
Passed! - Failed: 0, Passed:  504, ... ErsatzTV.Core.Tests.dll
Passed! - Failed: 0, Passed: 1467, ... ErsatzTV.Scanner.Tests.dll
```

`ErsatzTV.Tests` is absent. With this change a fifth line appears and its two `MultiSelectBaseTests` cases run for the first time since the project was added in #2738. Both pass, so nothing was broken, just never executed.

The version matches the pin already used by `ErsatzTV.Core.Tests`.

## Verification

Against `9cc771be`, using the command from `pr.yml`:

```
dotnet test --blame-hang-timeout "2m"
```

All five projects run, 1999 tests, 0 failures, no hangs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)