### PR TITLE
feat: add system theme option to ui settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+- Add `System` option to **Settings** > **UI** > **Theme**
+  - Follows the light or dark preference of the browser that is viewing ErsatzTV, and updates without a refresh when that preference changes
+
 ### Fixed
 - Fix regression from `v26.2.0` that caused channel logo watermarks to be ignored when the logo is a url
   - This affected external logo urls and generated channel logos

--- a/ErsatzTV.Application/Configuration/Commands/UpdateUiSettingsHandler.cs
+++ b/ErsatzTV.Application/Configuration/Commands/UpdateUiSettingsHandler.cs
@@ -17,9 +17,12 @@ public class UpdateUiSettingsHandler(IConfigElementRepository configElementRepos
     private async Task<Unit> ApplyUpdate(UiSettingsViewModel uiSettings, CancellationToken cancellationToken)
     {
         await configElementRepository.Upsert(
-            ConfigElementKey.PagesIsDarkMode,
-            uiSettings.IsDarkMode,
+            ConfigElementKey.PagesThemeMode,
+            uiSettings.ThemeMode,
             cancellationToken);
+
+        // the legacy dark mode flag is only used to migrate the theme mode setting
+        await configElementRepository.Delete(ConfigElementKey.PagesIsDarkMode, cancellationToken);
 
         await configElementRepository.Upsert(ConfigElementKey.PagesLanguage, uiSettings.Language, cancellationToken);
 

--- a/ErsatzTV.Application/Configuration/Queries/GetUiSettingsHandler.cs
+++ b/ErsatzTV.Application/Configuration/Queries/GetUiSettingsHandler.cs
@@ -8,6 +8,11 @@ public class GetUiSettingsHandler(IConfigElementRepository configElementReposito
 {
     public async Task<UiSettingsViewModel> Handle(GetUiSettings request, CancellationToken cancellationToken)
     {
+        Option<ThemeMode> pagesThemeMode = await configElementRepository.GetValue<ThemeMode>(
+            ConfigElementKey.PagesThemeMode,
+            cancellationToken);
+
+        // fall back to the legacy dark mode flag for installs that predate the theme mode setting
         Option<bool> pagesIsDarkMode = await configElementRepository.GetValue<bool>(
             ConfigElementKey.PagesIsDarkMode,
             cancellationToken);
@@ -18,7 +23,10 @@ public class GetUiSettingsHandler(IConfigElementRepository configElementReposito
 
         return new UiSettingsViewModel
         {
-            IsDarkMode = await pagesIsDarkMode.IfNoneAsync(true),
+            ThemeMode = pagesThemeMode.IfNone(
+                () => pagesIsDarkMode.Match(
+                    isDarkMode => isDarkMode ? ThemeMode.Dark : ThemeMode.Light,
+                    () => ThemeMode.Dark)),
             Language = await pagesLanguage.IfNoneAsync("en")
         };
     }

--- a/ErsatzTV.Application/Configuration/ThemeMode.cs
+++ b/ErsatzTV.Application/Configuration/ThemeMode.cs
@@ -1,0 +1,8 @@
+namespace ErsatzTV.Application.Configuration;
+
+public enum ThemeMode
+{
+    Dark = 0,
+    Light = 1,
+    System = 2
+}

--- a/ErsatzTV.Application/Configuration/UiSettingsViewModel.cs
+++ b/ErsatzTV.Application/Configuration/UiSettingsViewModel.cs
@@ -2,7 +2,7 @@ namespace ErsatzTV.Application.Configuration;
 
 public class UiSettingsViewModel
 {
-    public bool IsDarkMode { get; set; }
+    public ThemeMode ThemeMode { get; set; }
 
     public string Language { get; set; }
 }

--- a/ErsatzTV.Core/Domain/ConfigElementKey.cs
+++ b/ErsatzTV.Core/Domain/ConfigElementKey.cs
@@ -32,6 +32,7 @@ public class ConfigElementKey
     public static ConfigElementKey HDHRTunerCount => new("hdhr.tuner_count");
     public static ConfigElementKey HDHRUUID => new("hdhr.uuid");
     public static ConfigElementKey PagesIsDarkMode => new("pages.is_dark_mode");
+    public static ConfigElementKey PagesThemeMode => new("pages.theme_mode");
     public static ConfigElementKey PagesLanguage => new("pages.language");
     public static ConfigElementKey ChannelsPageSize => new("pages.channels.page_size");
     public static ConfigElementKey ChannelsShowDisabled => new("pages.channels.show_disabled");

--- a/ErsatzTV/Pages/Settings/UISettings.razor
+++ b/ErsatzTV/Pages/Settings/UISettings.razor
@@ -19,9 +19,10 @@
                 <div class="d-flex">
                     <MudText>Theme</MudText>
                 </div>
-                <MudSelect @bind-Value="_uiSettings.IsDarkMode">
-                    <MudSelectItem Value="@true">Dark</MudSelectItem>
-                    <MudSelectItem Value="@false">Light</MudSelectItem>
+                <MudSelect @bind-Value="_uiSettings.ThemeMode">
+                    <MudSelectItem Value="@ThemeMode.Dark">Dark</MudSelectItem>
+                    <MudSelectItem Value="@ThemeMode.Light">Light</MudSelectItem>
+                    <MudSelectItem Value="@ThemeMode.System">System</MudSelectItem>
                 </MudSelect>
             </MudStack>
             <MudStack Row="true" Breakpoint="Breakpoint.SmAndDown" Class="form-field-stack gap-md-8 mb-5">

--- a/ErsatzTV/Shared/MainLayout.razor
+++ b/ErsatzTV/Shared/MainLayout.razor
@@ -17,7 +17,7 @@
 @inject IHealthCheckService HealthCheckService;
 @inject IStringLocalizer<ErsatzTV.Locals.Shared.MainLayout> StringLocalizer;
 
-<MudThemeProvider Theme="ErsatzTvTheme" IsDarkMode="_isDarkMode"/>
+<MudThemeProvider @ref="_mudThemeProvider" Theme="ErsatzTvTheme" IsDarkMode="_isDarkMode" ObserveSystemDarkModeChange="@(_themeMode is ThemeMode.System)"/>
 <MudDialogProvider BackdropClick="false"/>
 <MudSnackbarProvider/>
 <MudPopoverProvider/>
@@ -279,7 +279,10 @@
     private int _playoutWarnings;
     private int _errors;
     private int _warnings;
+    private MudThemeProvider _mudThemeProvider;
+    private ThemeMode _themeMode = ThemeMode.Dark;
     private bool _isDarkMode = true;
+    private bool _systemIsDarkMode = true;
 
     protected override void OnInitialized()
     {
@@ -297,6 +300,45 @@
         await base.OnInitializedAsync();
         await HandleHealthCheckSummary(HealthCheckService.GetHealthCheckSummary(), CancellationToken.None);
     }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+
+        if (!firstRender || _mudThemeProvider is null)
+        {
+            return;
+        }
+
+        // the browser's color scheme is only available once we can use js interop
+        _systemIsDarkMode = await _mudThemeProvider.GetSystemDarkModeAsync();
+        if (_themeMode is ThemeMode.System)
+        {
+            ApplyThemeMode();
+            StateHasChanged();
+        }
+
+        await _mudThemeProvider.WatchSystemDarkModeAsync(OnSystemDarkModeChanged);
+    }
+
+    private async Task OnSystemDarkModeChanged(bool isDarkMode)
+    {
+        _systemIsDarkMode = isDarkMode;
+
+        if (_themeMode is ThemeMode.System)
+        {
+            ApplyThemeMode();
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private void ApplyThemeMode() =>
+        _isDarkMode = _themeMode switch
+        {
+            ThemeMode.Light => false,
+            ThemeMode.System => _systemIsDarkMode,
+            _ => true
+        };
 
     public void Dispose()
     {
@@ -415,9 +457,9 @@
             {
                 _searchTargets ??= await Mediator.Send(new QuerySearchTargets(), token);
 
-                _isDarkMode = await Mediator.Send(new GetConfigElementByKey(ConfigElementKey.PagesIsDarkMode), token)
-                    .MapT(result => !bool.TryParse(result.Value, out bool value) || value)
-                    .IfNoneAsync(true);
+                UiSettingsViewModel uiSettings = await Mediator.Send(new GetUiSettings(), token);
+                _themeMode = uiSettings.ThemeMode;
+                ApplyThemeMode();
 
                 _playoutWarnings = await Mediator.Send(new GetPlayoutWarningsCount(), token);
             }


### PR DESCRIPTION
**Settings** > **UI** > **Theme** offers `Dark` and `Light`. This adds `System`.

`System` follows the `prefers-color-scheme` preference of the browser viewing ErsatzTV, not any setting on the machine ErsatzTV runs on. When that preference changes while a page is open, the theme follows it without a refresh.

## Storage and upgrades

The theme was stored as a bool in `pages.is_dark_mode`, which can't express a third state. This adds `pages.theme_mode`, holding a `ThemeMode` enum.

Existing installs keep their theme. When `pages.theme_mode` is absent, `GetUiSettingsHandler` falls back to `pages.is_dark_mode` and maps it to `Dark` or `Light`. The legacy key is removed the first time UI settings are saved.

With neither key present the default is `Dark`, as before.

## MudBlazor wiring

`MudThemeProvider.WatchSystemDarkModeAsync` only subscribes a C# event. It does not start the `matchMedia` listener — that is started solely by `ObserveSystemDarkModeChange`.

So that parameter is bound to `_themeMode is ThemeMode.System`. Under `Dark` or `Light`, no listener is registered at all.

The initial value comes from `GetSystemDarkModeAsync` in `OnAfterRenderAsync(firstRender)`, since JS interop isn't available before then. One side effect: a `System` page prerenders with the dark palette, so a browser set to light shows a brief flash on first paint.

`_isDarkMode` still drives the existing `ersatztv-dark` / `ersatztv-light` class on `MudLayout`, so the `site.css` custom properties track the theme too.

## Verification

Run against an isolated config folder, driven in a browser:

- fresh database → `Dark`, unchanged
- `System` + browser in light → light; `System` + browser in dark → dark
- flipping the browser preference with the page open → follows both ways, no refresh
- `Light` + browser in dark → stays light, and no `prefers-color-scheme` listener is registered
- `pages.is_dark_mode` = `False` with no `pages.theme_mode` → loads as `Light`

`dotnet test --blame-hang-timeout "2m"` passes across all five test projects (2003 passed, 1 skipped).

A collaboration between @Ministorm3 and Claude Code
